### PR TITLE
Add three functions to support new scrypt-sv boilerplate demo 'advancedcounter'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { buildContractClass, bsv } from './local';
-export { lockScriptTx, unlockScriptTx, getSighashPreimage, getSignature, showError } from './remote';
+export { lockScriptTx, unlockScriptTx, unlockFundedScriptTx, getSighashPreimage, getFundedSighashPreimage, getSignature, showError } from './remote';


### PR DESCRIPTION
Add exported async functions:
    getFundedSighashPreimage()
    unlockFundedScriptTx()

They both use new function buildFundedScriptUnlockTx(), and enable building a transaction with an additional input, and change output.